### PR TITLE
fix(op): move operator to native utf8.ValidString method

### DIFF
--- a/operators/validate_utf8_encoding.go
+++ b/operators/validate_utf8_encoding.go
@@ -14,14 +14,10 @@
 
 package operators
 
-import engine "github.com/jptosso/coraza-waf"
+import (
+	"unicode/utf8"
 
-const (
-	UNICODE_ERROR_CHARACTERS_MISSING   = -1
-	UNICODE_ERROR_INVALID_ENCODING     = -2
-	UNICODE_ERROR_OVERLONG_CHARACTER   = -3
-	UNICODE_ERROR_RESTRICTED_CHARACTER = -4
-	UNICODE_ERROR_DECODING_ERROR       = -5
+	engine "github.com/jptosso/coraza-waf"
 )
 
 type ValidateUtf8Encoding struct{}
@@ -31,120 +27,5 @@ func (o *ValidateUtf8Encoding) Init(data string) error {
 }
 
 func (o *ValidateUtf8Encoding) Evaluate(tx *engine.Transaction, value string) bool {
-	//TODO https://golang.org/pkg/unicode/utf8/#ValidString should be enough but it fails (?)
-	if value == "" {
-		return false
-	}
-	str_c := []byte(value)
-	bytes_left := len(str_c)
-	for i := 0; i < len(value); {
-		rc := detectUtf8Character(str_c[i:], bytes_left)
-		//We use switch in case we debug information
-		switch rc {
-		case UNICODE_ERROR_CHARACTERS_MISSING:
-			return true
-		case UNICODE_ERROR_INVALID_ENCODING:
-			return true
-		case UNICODE_ERROR_OVERLONG_CHARACTER:
-			return true
-		case UNICODE_ERROR_RESTRICTED_CHARACTER:
-			return true
-		case UNICODE_ERROR_DECODING_ERROR:
-			return true
-		}
-
-		if rc <= 0 {
-			return true
-		}
-
-		i += rc
-		bytes_left -= rc
-	}
-	return false
-}
-
-func detectUtf8Character(p_read []byte, length int) int {
-	var c byte
-	var unicode_len, d int
-	if len(p_read) == 0 {
-		return UNICODE_ERROR_DECODING_ERROR
-	}
-	c = p_read[0]
-
-	/* If first byte begins with binary 0 it is single byte encoding */
-	if (c & 0x80) == 0 {
-		/* single byte unicode (7 bit ASCII equivilent) has no validation */
-		return 1
-	} else if (c & 0xE0) == 0xC0 {
-		/* If first byte begins with binary 110 it is two byte encoding*/
-		/* check we have at least two bytes */
-		if length < 2 {
-			unicode_len = UNICODE_ERROR_CHARACTERS_MISSING
-		} else if (p_read[1] & 0xC0) != 0x80 {
-			/* check second byte starts with binary 10 */
-			unicode_len = UNICODE_ERROR_INVALID_ENCODING
-		} else {
-			unicode_len = 2
-			/* compute character number */
-			d = int(((c & 0x1F) << 6) | (p_read[1] & 0x3F))
-		}
-	} else if (c & 0xF0) == 0xE0 {
-		/* If first byte begins with binary 1110 it is three byte encoding */
-		/* check we have at least three bytes */
-		if length < 3 {
-			unicode_len = UNICODE_ERROR_CHARACTERS_MISSING
-		} else if (p_read[1] & 0xC0) != 0x80 {
-			/* check second byte starts with binary 10 */
-			unicode_len = UNICODE_ERROR_INVALID_ENCODING
-		} else if (p_read[2] & 0xC0) != 0x80 {
-			/* check third byte starts with binary 10 */
-			unicode_len = UNICODE_ERROR_INVALID_ENCODING
-		} else {
-			unicode_len = 3
-			/* compute character number */
-			d = int(((c & 0x0F) << 12) | ((p_read[1] & 0x3F) << 6) | (p_read[2] & 0x3F))
-		}
-	} else if (c & 0xF8) == 0xF0 {
-		/* If first byte begins with binary 11110 it is four byte encoding */
-		/* restrict characters to UTF-8 range (U+0000 - U+10FFFF)*/
-		if c >= 0xF5 {
-			return UNICODE_ERROR_RESTRICTED_CHARACTER
-		}
-		/* check we have at least four bytes */
-		if length < 4 {
-			unicode_len = UNICODE_ERROR_CHARACTERS_MISSING
-		} else if (p_read[1] & 0xC0) != 0x80 {
-			unicode_len = UNICODE_ERROR_INVALID_ENCODING
-		} else if (p_read[2] & 0xC0) != 0x80 {
-			unicode_len = UNICODE_ERROR_INVALID_ENCODING
-		} else if (p_read[3] & 0xC0) != 0x80 {
-			unicode_len = UNICODE_ERROR_INVALID_ENCODING
-		} else {
-			unicode_len = 4
-			/* compute character number */
-			d = int(((c & 0x07) << 18) | ((p_read[1] & 0x3F) << 12) | ((p_read[2] & 0x3F) << 6) | (p_read[3] & 0x3F))
-		}
-	} else {
-		/* any other first byte is invalid (RFC 3629) */
-		return UNICODE_ERROR_INVALID_ENCODING
-	}
-
-	/* invalid UTF-8 character number range (RFC 3629) */
-	if (d >= 0xD800) && (d <= 0xDFFF) {
-		return UNICODE_ERROR_RESTRICTED_CHARACTER
-	}
-
-	/* check for overlong */
-	if (unicode_len == 4) && (d < 0x010000) {
-		/* four byte could be represented with less bytes */
-		return UNICODE_ERROR_OVERLONG_CHARACTER
-	} else if (unicode_len == 3) && (d < 0x0800) {
-		/* three byte could be represented with less bytes */
-		return UNICODE_ERROR_OVERLONG_CHARACTER
-	} else if (unicode_len == 2) && (d < 0x80) {
-		/* two byte could be represented with less bytes */
-		return UNICODE_ERROR_OVERLONG_CHARACTER
-	}
-
-	return unicode_len
+	return utf8.ValidString(value)
 }

--- a/testdata/operators/validateUtf8Encoding.json
+++ b/testdata/operators/validateUtf8Encoding.json
@@ -2,13 +2,13 @@
    {
       "name" : "validateUtf8Encoding",
       "type" : "op",
-      "ret" : 0,
+      "ret" : 1,
       "input" : "",
       "param" : ""
    },
    {
       "name" : "validateUtf8Encoding",
-      "ret" : 0,
+      "ret" : 1,
       "type" : "op",
       "input" : "á½Î±Î»Î¿Î½ ÏÎ±Î³Îµá¿Î½ Î´á½»Î½Î±Î¼Î±Î¹Î ÏÎ¿á¿¦ÏÎ¿ Î¿á½ Î¼Îµ Î²Î»á½±ÏÏÎµÎ¹.",
       "param" : ""
@@ -16,35 +16,35 @@
    {
       "input" : "Je peux manger du verre, Ã§a ne me fait pas de mal.",
       "param" : "",
-      "ret" : 0,
+      "ret" : 1,
       "type" : "op",
       "name" : "validateUtf8Encoding"
    },
    {
       "input" : "Puedo comer vidrio, no me hace daÃ±o.",
       "param" : "",
-      "ret" : 0,
+      "ret" : 1,
       "type" : "op",
       "name" : "validateUtf8Encoding"
    },
    {
       "param" : "",
       "input" : "Mi povas manÄi vitron, Äi ne damaÄas min.",
-      "ret" : 0,
+      "ret" : 1,
       "type" : "op",
       "name" : "validateUtf8Encoding"
    },
    {
       "param" : "",
       "input" : "Ic mÃ¦g glÃ¦s eotan ond hit ne hearmiaÃ° me.",
-      "ret" : 0,
+      "ret" : 1,
       "type" : "op",
       "name" : "validateUtf8Encoding"
    },
    {
       "name" : "validateUtf8Encoding",
       "type" : "op",
-      "ret" : 0,
+      "ret" : 1,
       "input" : "ÐÐ¾Ð³Ñ ÑÐµÑÑÐ¸ ÑÑÐ°ÐºÐ»Ð¾ Ð° Ð´Ð° Ð¼Ð¸ Ð½Ðµ ÑÐºÐ¾Ð´Ð¸.",
       "param" : ""
    },
@@ -52,11 +52,11 @@
       "param" : "",
       "input" : "Ð¯ Ð¼Ð¾Ð³Ñ ÐµÑÑÑ ÑÑÐµÐºÐ»Ð¾, Ð¾Ð½Ð¾ Ð¼Ð½Ðµ Ð½Ðµ Ð²ÑÐµÐ´Ð¸Ñ.",
       "name" : "validateUtf8Encoding",
-      "ret" : 0,
+      "ret" : 1,
       "type" : "op"
    },
    {
-      "ret" : 0,
+      "ret" : 1,
       "type" : "op",
       "name" : "validateUtf8Encoding",
       "param" : "",
@@ -64,7 +64,7 @@
    },
    {
       "name" : "validateUtf8Encoding",
-      "ret" : 0,
+      "ret" : 1,
       "type" : "op",
       "param" : "",
       "input" : "Ø¬Ø§Ù ÙÙÙ Ø¨ÙÙØ±Ù Ø¨Ú­Ø§ Ø¶Ø±Ø±Ù Ø·ÙÙÙÙÙØ²"
@@ -73,25 +73,25 @@
       "input" : "à¤®à¥à¤ à¤à¤¾à¤à¤ à¤à¤¾ à¤¸à¤à¤¤à¤¾ à¤¹à¥à¤, à¤®à¥à¤à¥ à¤à¤¸ à¤¸à¥ à¤à¥à¤ à¤ªà¥à¤¡à¤¾ à¤¨à¤¹à¥à¤ à¤¹à¥à¤¤à¥.",
       "param" : "",
       "name" : "validateUtf8Encoding",
-      "ret" : 0,
+      "ret" : 1,
       "type" : "op"
    },
    {
       "name" : "validateUtf8Encoding",
       "type" : "op",
-      "ret" : 0,
+      "ret" : 1,
       "param" : "",
       "input" : "Ø£ÙØ§ ÙØ§Ø¯Ø± Ø¹ÙÙ Ø£ÙÙ Ø§ÙØ²Ø¬Ø§Ø¬ Ù ÙØ°Ø§ ÙØ§ ÙØ¤ÙÙÙÙ."
    },
    {
       "param" : "",
       "input" : "×× × ×××× ××××× ××××××ª ××× ×× ××××§ ××.",
-      "ret" : 0,
+      "ret" : 1,
       "type" : "op",
       "name" : "validateUtf8Encoding"
    },
    {
-      "ret" : 0,
+      "ret" : 1,
       "type" : "op",
       "name" : "validateUtf8Encoding",
       "param" : "",
@@ -101,11 +101,11 @@
       "param" : "",
       "input" : "à¸à¸±à¸à¸à¸´à¸à¸à¸£à¸°à¸à¸à¹à¸à¹ à¹à¸à¹à¸¡à¸±à¸à¹à¸¡à¹à¸à¸³à¹à¸«à¹à¸à¸±à¸à¹à¸à¹à¸",
       "type" : "op",
-      "ret" : 0,
+      "ret" : 1,
       "name" : "validateUtf8Encoding"
    },
    {
-      "ret" : 0,
+      "ret" : 1,
       "type" : "op",
       "name" : "validateUtf8Encoding",
       "param" : "",
@@ -116,18 +116,18 @@
       "param" : "",
       "name" : "validateUtf8Encoding",
       "type" : "op",
-      "ret" : 0
+      "ret" : 1
    },
    {
       "input" : "Ãg get etiÃ° gler Ã¡n Ã¾ess aÃ° meiÃ°a mig.",
       "param" : "",
-      "ret" : 0,
+      "ret" : 1,
       "type" : "op",
       "name" : "validateUtf8Encoding"
    },
    {
       "type" : "op",
-      "ret" : 0,
+      "ret" : 1,
       "name" : "validateUtf8Encoding",
       "input" : "à¤à¤¾à¤à¤ à¤¶à¤à¥à¤¨à¥à¤®à¥à¤¯à¤¤à¥à¤¤à¥à¤®à¥ à¥¤ à¤¨à¥à¤ªà¤¹à¤¿à¤¨à¤¸à¥à¤¤à¤¿ à¤®à¤¾à¤®à¥ à¥¥",
       "param" : ""
@@ -136,26 +136,26 @@
       "input" : "â â â â â â â â â â â â â â â â â â â â â â â â â â â â â â â â ¥â â â â â ",
       "param" : "",
       "name" : "validateUtf8Encoding",
-      "ret" : 0,
+      "ret" : 1,
       "type" : "op"
    },
    {
       "name" : "validateUtf8Encoding",
       "type" : "op",
-      "ret" : 0,
+      "ret" : 1,
       "param" : "",
       "input" : "Jeg kan spise glas, det gÃ¸r ikke ondt pÃ¥ mig."
    },
    {
       "name" : "validateUtf8Encoding",
-      "ret" : 0,
+      "ret" : 1,
       "type" : "op",
       "param" : "",
       "input" : "Meg tudom enni az Ã¼veget, nem lesz tÅle bajom."
    },
    {
       "type" : "op",
-      "ret" : 0,
+      "ret" : 1,
       "name" : "validateUtf8Encoding",
       "param" : "",
       "input" : "Ma vÃµin klaasi sÃ¼Ã¼a, see ei tee mulle midagi."
@@ -164,7 +164,7 @@
       "input" : "Mohu jÃ­st sklo, neublÃ­Å¾Ã­ mi.",
       "param" : "",
       "type" : "op",
-      "ret" : 0,
+      "ret" : 1,
       "name" : "validateUtf8Encoding"
    },
    {
@@ -172,19 +172,19 @@
       "input" : "MÃ´Å¾em jesÅ¥ sklo. NezranÃ­ ma.",
       "name" : "validateUtf8Encoding",
       "type" : "op",
-      "ret" : 0
+      "ret" : 1
    },
    {
       "param" : "",
       "input" : "MogÄ jeÅÄ szkÅo i mi nie szkodzi.",
       "type" : "op",
-      "ret" : 0,
+      "ret" : 1,
       "name" : "validateUtf8Encoding"
    },
    {
       "param" : "",
       "input" : "â®Eâda=Qnâââf(i)=âg(i)âxââ:âxâ=âââxâÎ±â§Â¬Î²=Â¬(Â¬Î±â¨Î²)ââââââ¤âââââââ¥<aâ bâ¡câ¤dâªâ¤â(AâB)2Hâ+Oââ2HâOR=4.7kÎ©â200mmââââ'Â´`âââââ â¡â°â¢3â4ââ5/+5â¢â¦1lI|0OD8Bâ¬",
-      "ret" : 0,
+      "ret" : 1,
       "type" : "op",
       "name" : "validateUtf8Encoding"
    },
@@ -192,12 +192,12 @@
       "input" : "\\u0000\\xe4",
       "param" : "",
       "name" : "validateUtf8Encoding",
-      "ret" : 1,
+      "ret" : 0,
       "type" : "op"
    },
    {
       "name" : "validateUtf8Encoding",
-      "ret" : 1,
+      "ret" : 0,
       "type" : "op",
       "input" : "\\xe4",
       "param" : ""
@@ -205,20 +205,20 @@
    {
       "name" : "validateUtf8Encoding",
       "type" : "op",
-      "ret" : 1,
+      "ret" : 0,
       "input" : "\\x03\\xbf",
       "param" : ""
    },
    {
       "type" : "op",
-      "ret" : 1,
+      "ret" : 0,
       "name" : "validateUtf8Encoding",
       "input" : "\\xc9\\x3b",
       "param" : ""
    },
    {
       "name" : "validateUtf8Encoding",
-      "ret" : 1,
+      "ret" : 0,
       "type" : "op",
       "param" : "",
       "input" : "\\xFF\\u0000"


### PR DESCRIPTION
- cleaned up operator
- use native utf8.ValidString func
- fix test results

Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>