### PR TITLE
V2/parser rework

### DIFF
--- a/actions/chain.go
+++ b/actions/chain.go
@@ -22,7 +22,7 @@ import (
 type chainFn struct{}
 
 func (a *chainFn) Init(r *coraza.Rule, b1 string) error {
-	r.Chain = coraza.NewRule()
+	r.HasChain = true
 	return nil
 }
 

--- a/loggers/concurrent_writer_test.go
+++ b/loggers/concurrent_writer_test.go
@@ -29,7 +29,6 @@ func TestCLogFileCreation(t *testing.T) {
 	if err != nil {
 		t.Error("failed to create concurrent logger file")
 	}
-	logger := &concurrentWriter{}
 	l, err := NewAuditLogger()
 	if err != nil {
 		t.Error("failed to create audit logger", err)
@@ -39,7 +38,7 @@ func TestCLogFileCreation(t *testing.T) {
 	l.fileMode = 0777
 	l.dirMode = 0777
 	l.formatter = jsonFormatter
-	if err := logger.Init(l); err != nil {
+	if err := l.SetWriter("concurrent"); err != nil {
 		t.Error(err)
 	}
 	ts := time.Now().UnixNano()
@@ -51,7 +50,7 @@ func TestCLogFileCreation(t *testing.T) {
 			Response:      AuditTransactionResponse{},
 		},
 	}
-	if err := logger.Write(al); err != nil {
+	if err := l.Write(al); err != nil {
 		t.Error("failed to write to logger: ", err)
 	}
 	tt := time.Unix(0, ts)

--- a/loggers/logger.go
+++ b/loggers/logger.go
@@ -34,6 +34,8 @@ type LoggerOptions struct {
 	// Dir provides a unique path to write files, it's mostly
 	// used for concurrent logging
 	Dir string
+
+	Formatter LogFormatter
 }
 
 // Logger is a wrapper to hold configurations, a writer and a formatter
@@ -89,15 +91,25 @@ func (l *Logger) SetWriter(name string) error {
 		return err
 	}
 	l.writer = writer
-	return l.writer.Init(l)
+	return l.writer.Init(LoggerOptions{
+		DirMode:   l.dirMode,
+		FileMode:  l.fileMode,
+		File:      l.file,
+		Dir:       l.directory,
+		Formatter: l.formatter,
+	})
 }
 
 // SetFile sets the file for the logger
 // The file path must exist and must be absolute
 func (l *Logger) SetFile(file string) error {
-	if !filepath.IsAbs(file) {
-		return fmt.Errorf("file path must be absolute")
-	}
+	/*
+		File can be a url
+		if !filepath.IsAbs(file) {
+			return fmt.Errorf("file path must be absolute")
+		}
+	*/
+
 	l.file = file
 	return nil
 }
@@ -131,7 +143,7 @@ type LogFormatter = func(al AuditLog) ([]byte, error)
 // An output stream may be a file, a socket, an http request, etc
 type LogWriter interface {
 	// In case the writer requires previous preparations
-	Init(*Logger) error
+	Init(LoggerOptions) error
 	// Writes the audit log using the Logger properties
 	Write(AuditLog) error
 	// Closes the writer if required

--- a/loggers/serial_writer.go
+++ b/loggers/serial_writer.go
@@ -15,31 +15,35 @@
 package loggers
 
 import (
+	"fmt"
 	"log"
 	"os"
 )
 
 // serialWriter is used to store logs in a single file
 type serialWriter struct {
-	file *os.File
-	log  log.Logger
-	l    *Logger
+	file    *os.File
+	log     log.Logger
+	options LoggerOptions
 }
 
-func (sl *serialWriter) Init(l *Logger) error {
-	sl.l = l
+func (sl *serialWriter) Init(l LoggerOptions) error {
+	sl.options = l
 	var err error
-	sl.file, err = os.OpenFile(l.file, os.O_APPEND|os.O_CREATE|os.O_WRONLY, l.fileMode)
+	sl.file, err = os.OpenFile(sl.options.File, os.O_APPEND|os.O_CREATE|os.O_WRONLY, sl.options.FileMode)
 	if err != nil {
 		return err
 	}
 	sl.log.SetFlags(0)
 	sl.log.SetOutput(sl.file)
+	if sl.options.Formatter == nil {
+		return fmt.Errorf("formetter cannot be nil")
+	}
 	return nil
 }
 
 func (sl *serialWriter) Write(al AuditLog) error {
-	data, err := sl.l.formatter(al)
+	data, err := sl.options.Formatter(al)
 	if err != nil {
 		return err
 	}

--- a/loggers/serial_writer_test.go
+++ b/loggers/serial_writer_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestSerialLogger_Write(t *testing.T) {
-	l := &serialWriter{}
 	tmp := path.Join("/tmp", utils.SafeRandom(10)+"-audit.log")
 	defer os.Remove(tmp)
 	logger, err := NewAuditLogger()
@@ -33,7 +32,7 @@ func TestSerialLogger_Write(t *testing.T) {
 		t.Error(err)
 	}
 	logger.file = tmp
-	err = l.Init(logger)
+	err = logger.SetWriter("serial")
 	if err != nil {
 		t.Error(err)
 	}
@@ -50,7 +49,7 @@ func TestSerialLogger_Write(t *testing.T) {
 			},
 		},
 	}
-	if err := l.Write(al); err != nil {
+	if err := logger.Write(al); err != nil {
 		t.Error("failed to write to serial logger")
 	}
 

--- a/rule.go
+++ b/rule.go
@@ -215,6 +215,8 @@ type Rule struct {
 
 	// Used for error logging
 	Disruptive bool
+
+	HasChain bool
 }
 
 // Evaluate will evaluate the current rule for the indicated transaction

--- a/seclang/directives.go
+++ b/seclang/directives.go
@@ -85,9 +85,9 @@ func directiveSecAction(w *coraza.Waf, opts string) error {
 }
 
 func directiveSecRule(w *coraza.Waf, opts string) error {
-	line, _ := w.GetConfig("parser_last_line").(int)
-	configFile, _ := w.GetConfig("parser_config_file").(string)
-	configDir, _ := w.GetConfig("parser_config_dir").(string)
+	line, _ := w.GetConfig("parser_last_line", 0).(int)
+	configFile, _ := w.GetConfig("parser_config_file", "").(string)
+	configDir, _ := w.GetConfig("parser_config_dir", "").(string)
 	rule, err := ParseRule(RuleOptions{
 		Waf:          w,
 		Data:         opts,
@@ -256,7 +256,7 @@ func directiveSecHashEngine(w *coraza.Waf, opts string) error {
 }
 
 func directiveSecDefaultAction(w *coraza.Waf, opts string) error {
-	da, ok := w.GetConfig("rule_default_actions").([]string)
+	da, ok := w.GetConfig("rule_default_actions", []string{}).([]string)
 	if !ok {
 		da = []string{}
 	}

--- a/seclang/directives.go
+++ b/seclang/directives.go
@@ -423,6 +423,24 @@ func directiveSecDebugLogLevel(w *coraza.Waf, opts string) error {
 	return w.SetLogLevel(lvl)
 }
 
+func directiveSecRuleUpdateTargetById(w *coraza.Waf, opts string) error {
+	spl := strings.SplitN(opts, " ", 2)
+	if len(spl) != 2 {
+		return errors.New("syntax error: SecRuleUpdateTargetById id target")
+	}
+	id, err := strconv.Atoi(spl[0])
+	if err != nil {
+		return err
+	}
+	rule := w.Rules.FindByID(id)
+	rp := &RuleParser{
+		rule:           rule,
+		options:        RuleOptions{},
+		defaultActions: map[types.RulePhase][]ruleAction{},
+	}
+	return rp.ParseVariables(strings.Trim(spl[1], "\""))
+}
+
 func parseBoolean(data string) bool {
 	data = strings.ToLower(data)
 	return data == "on"
@@ -450,6 +468,7 @@ var (
 	_ directive = directiveSecMarker
 	_ directive = directiveSecRemoteRules
 	_ directive = directiveSecSensorID
+	_ directive = directiveSecRuleUpdateTargetById
 )
 
 var directivesMap = map[string]directive{
@@ -515,7 +534,7 @@ var directivesMap = map[string]directive{
 	"seccookieformat":          directiveUnsupported,
 	"secruleupdatetargetbytag": directiveUnsupported,
 	"secruleupdatetargetbymsg": directiveUnsupported,
-	"secruleupdatetargetbyid":  directiveUnsupported,
+	"secruleupdatetargetbyid":  directiveSecRuleUpdateTargetById,
 	"secruleupdateactionbyid":  directiveUnsupported,
 	"secrulescript":            directiveUnsupported,
 	"secruleperftime":          directiveUnsupported,

--- a/seclang/directives.go
+++ b/seclang/directives.go
@@ -22,233 +22,261 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/jptosso/coraza-waf/v2"
 	"github.com/jptosso/coraza-waf/v2/types"
 	"go.uber.org/zap"
 )
 
-type directive = func(p *Parser, opts string) error
+type directive = func(w *coraza.Waf, opts string) error
 
-func directiveSecComponentSignature(p *Parser, opts string) error {
-	p.Waf.ComponentNames = append(p.Waf.ComponentNames, opts)
+func directiveSecComponentSignature(w *coraza.Waf, opts string) error {
+	w.ComponentNames = append(w.ComponentNames, opts)
 	return nil
 }
 
-func directiveSecMarker(p *Parser, opts string) error {
-	rule, _ := p.parseRule(`"id:1, pass, nolog"`, false)
+func directiveSecMarker(w *coraza.Waf, opts string) error {
+	rule, err := ParseRule(RuleOptions{
+		Waf:          w,
+		Data:         "id:1, pass, nolog",
+		WithOperator: false,
+	})
+	if err != nil {
+		return err
+	}
 	rule.SecMark = opts
 	rule.ID = 0
 	rule.Phase = 0
-	if err := p.Waf.Rules.Add(rule); err != nil {
-		if perr := p.log(fmt.Sprintf("Failed to compile rule (%s): %s", err, opts)); perr != nil {
+	if err := w.Rules.Add(rule); err != nil {
+		if perr := fmt.Errorf("Failed to compile rule (%s): %s", err, opts); perr != nil {
 			return perr // can't write to log, return this instead
 		}
 		return err
 	}
-	p.Waf.Logger.Debug("added secmark rule")
+	w.Logger.Debug("added secmark rule")
 	return nil
 }
 
-func directiveSecAction(p *Parser, opts string) error {
-	rule, err := p.parseRule(opts, false)
+func directiveSecAction(w *coraza.Waf, opts string) error {
+	rule, err := ParseRule(RuleOptions{
+		Waf:          w,
+		Data:         opts,
+		WithOperator: false,
+	})
 	if err != nil {
-		if perr := p.log(fmt.Sprintf("Failed to compile rule (%s): %s", err, opts)); perr != nil {
+		if perr := fmt.Errorf("Failed to compile rule (%s): %s", err, opts); perr != nil {
 			return perr // can't write to log, return this instead
 		}
 		return err
 	}
-	if err := p.Waf.Rules.Add(rule); err != nil {
-		if perr := p.log(fmt.Sprintf("Failed to compile rule (%s): %s", err, opts)); perr != nil {
+	if err := w.Rules.Add(rule); err != nil {
+		if perr := fmt.Errorf("Failed to compile rule (%s): %s", err, opts); perr != nil {
 			return perr // can't write to log, return this instead
 		}
 		return err
 	}
-	p.Waf.Logger.Debug("Added SecAction",
+	w.Logger.Debug("Added SecAction",
 		zap.String("rule", opts),
 	)
 	return nil
 }
 
-func directiveSecRule(p *Parser, opts string) error {
-	rule, err := p.parseRule(opts, true)
+func directiveSecRule(w *coraza.Waf, opts string) error {
+	line, _ := w.GetConfig("parser_last_line").(int)
+	configFile, _ := w.GetConfig("parser_config_file").(string)
+	configDir, _ := w.GetConfig("parser_config_dir").(string)
+	rule, err := ParseRule(RuleOptions{
+		Waf:          w,
+		Data:         opts,
+		WithOperator: true,
+		Line:         line,
+		ConfigFile:   configFile,
+		ConfigDir:    configDir,
+	})
 	if err != nil {
-		if perr := p.log(fmt.Sprintf("Failed to compile rule (%s): %s", err, opts)); perr != nil {
+		if perr := fmt.Errorf("Failed to compile rule (%s): %s", err, opts); perr != nil {
 			return perr // can't write to log, return this instead
 		}
 		return err
 	}
-	return p.Waf.Rules.Add(rule)
+	return w.Rules.Add(rule)
 }
 
-func directiveSecResponseBodyAccess(p *Parser, opts string) error {
-	p.Waf.ResponseBodyAccess = (strings.ToLower(opts) == "on")
+func directiveSecResponseBodyAccess(w *coraza.Waf, opts string) error {
+	w.ResponseBodyAccess = (strings.ToLower(opts) == "on")
 	return nil
 }
 
-func directiveSecRequestBodyLimit(p *Parser, opts string) error {
+func directiveSecRequestBodyLimit(w *coraza.Waf, opts string) error {
 	limit, _ := strconv.ParseInt(opts, 10, 64)
-	p.Waf.RequestBodyLimit = limit
+	w.RequestBodyLimit = limit
 	return nil
 }
 
-func directiveSecRequestBodyAccess(p *Parser, opts string) error {
-	p.Waf.RequestBodyAccess = (strings.ToLower(opts) == "on")
+func directiveSecRequestBodyAccess(w *coraza.Waf, opts string) error {
+	w.RequestBodyAccess = (strings.ToLower(opts) == "on")
 	return nil
 }
 
-func directiveSecRuleEngine(p *Parser, opts string) error {
+func directiveSecRuleEngine(w *coraza.Waf, opts string) error {
 	engine, err := types.ParseRuleEngineStatus(opts)
-	p.Waf.RuleEngine = engine
+	w.RuleEngine = engine
 	return err
 }
 
-func directiveUnsupported(p *Parser, opts string) error {
+func directiveUnsupported(w *coraza.Waf, opts string) error {
 	return nil
 }
 
-func directiveSecWebAppID(p *Parser, opts string) error {
-	p.Waf.WebAppID = opts
+func directiveSecWebAppID(w *coraza.Waf, opts string) error {
+	w.WebAppID = opts
 	return nil
 }
 
-func directiveSecTmpDir(p *Parser, opts string) error {
-	p.Waf.TmpDir = opts
+func directiveSecTmpDir(w *coraza.Waf, opts string) error {
+	w.TmpDir = opts
 	return nil
 }
 
-func directiveSecServerSignature(p *Parser, opts string) error {
-	p.Waf.ServerSignature = opts
+func directiveSecServerSignature(w *coraza.Waf, opts string) error {
+	w.ServerSignature = opts
 	return nil
 }
 
-func directiveSecRuleRemoveByTag(p *Parser, opts string) error {
-	for _, r := range p.Waf.Rules.FindByTag(opts) {
-		p.Waf.Rules.DeleteByID(r.ID)
+func directiveSecRuleRemoveByTag(w *coraza.Waf, opts string) error {
+	for _, r := range w.Rules.FindByTag(opts) {
+		w.Rules.DeleteByID(r.ID)
 	}
 	return nil
 }
 
-func directiveSecRuleRemoveByMsg(p *Parser, opts string) error {
-	for _, r := range p.Waf.Rules.FindByMsg(opts) {
-		p.Waf.Rules.DeleteByID(r.ID)
+func directiveSecRuleRemoveByMsg(w *coraza.Waf, opts string) error {
+	for _, r := range w.Rules.FindByMsg(opts) {
+		w.Rules.DeleteByID(r.ID)
 	}
 	return nil
 }
 
-func directiveSecRuleRemoveByID(p *Parser, opts string) error {
+func directiveSecRuleRemoveByID(w *coraza.Waf, opts string) error {
 	id, _ := strconv.Atoi(opts)
-	p.Waf.Rules.DeleteByID(id)
+	w.Rules.DeleteByID(id)
 	return nil
 }
 
-func directiveSecResponseBodyMimeTypesClear(p *Parser, opts string) error {
-	p.Waf.ResponseBodyMimeTypes = []string{}
+func directiveSecResponseBodyMimeTypesClear(w *coraza.Waf, opts string) error {
+	w.ResponseBodyMimeTypes = []string{}
 	return nil
 }
 
-func directiveSecResponseBodyMimeType(p *Parser, opts string) error {
-	p.Waf.ResponseBodyMimeTypes = strings.Split(opts, " ")
+func directiveSecResponseBodyMimeType(w *coraza.Waf, opts string) error {
+	w.ResponseBodyMimeTypes = strings.Split(opts, " ")
 	return nil
 }
 
-func directiveSecResponseBodyLimitAction(p *Parser, opts string) error {
-	p.Waf.RejectOnResponseBodyLimit = (strings.ToLower(opts) == "reject")
+func directiveSecResponseBodyLimitAction(w *coraza.Waf, opts string) error {
+	w.RejectOnResponseBodyLimit = (strings.ToLower(opts) == "reject")
 	return nil
 }
 
-func directiveSecResponseBodyLimit(p *Parser, opts string) error {
+func directiveSecResponseBodyLimit(w *coraza.Waf, opts string) error {
 	var err error
-	p.Waf.ResponseBodyLimit, err = strconv.ParseInt(opts, 10, 64)
+	w.ResponseBodyLimit, err = strconv.ParseInt(opts, 10, 64)
 	return err
 }
 
-func directiveSecRequestBodyLimitAction(p *Parser, opts string) error {
-	p.Waf.RejectOnRequestBodyLimit = (strings.ToLower(opts) == "reject")
+func directiveSecRequestBodyLimitAction(w *coraza.Waf, opts string) error {
+	w.RejectOnRequestBodyLimit = (strings.ToLower(opts) == "reject")
 	return nil
 }
 
-func directiveSecRequestBodyInMemoryLimit(p *Parser, opts string) error {
-	p.Waf.RequestBodyInMemoryLimit, _ = strconv.ParseInt(opts, 10, 64)
+func directiveSecRequestBodyInMemoryLimit(w *coraza.Waf, opts string) error {
+	w.RequestBodyInMemoryLimit, _ = strconv.ParseInt(opts, 10, 64)
 	return nil
 }
 
-func directiveSecRemoteRulesFailAction(p *Parser, opts string) error {
-	p.Waf.AbortOnRemoteRulesFail = (strings.ToLower(opts) == "abort")
+func directiveSecRemoteRulesFailAction(w *coraza.Waf, opts string) error {
+	w.AbortOnRemoteRulesFail = (strings.ToLower(opts) == "abort")
 	return nil
 }
 
-func directiveSecRemoteRules(p *Parser, opts string) error {
+func directiveSecRemoteRules(w *coraza.Waf, opts string) error {
 	return fmt.Errorf("not implemented")
 }
 
-func directiveSecConnWriteStateLimit(p *Parser, opts string) error {
+func directiveSecConnWriteStateLimit(w *coraza.Waf, opts string) error {
 	return nil
 }
 
-func directiveSecSensorID(p *Parser, opts string) error {
-	p.Waf.SensorID = opts
+func directiveSecSensorID(w *coraza.Waf, opts string) error {
+	w.SensorID = opts
 	return nil
 }
 
-func directiveSecConnReadStateLimit(p *Parser, opts string) error {
+func directiveSecConnReadStateLimit(w *coraza.Waf, opts string) error {
 	return nil
 }
 
-func directiveSecPcreMatchLimitRecursion(p *Parser, opts string) error {
+func directiveSecPcreMatchLimitRecursion(w *coraza.Waf, opts string) error {
 	return nil
 }
 
-func directiveSecPcreMatchLimit(p *Parser, opts string) error {
+func directiveSecPcreMatchLimit(w *coraza.Waf, opts string) error {
 	return nil
 }
 
-func directiveSecHTTPBlKey(p *Parser, opts string) error {
+func directiveSecHTTPBlKey(w *coraza.Waf, opts string) error {
 	return nil
 }
 
-func directiveSecGsbLookupDb(p *Parser, opts string) error {
+func directiveSecGsbLookupDb(w *coraza.Waf, opts string) error {
 	return nil
 }
 
-func directiveSecHashMethodPm(p *Parser, opts string) error {
+func directiveSecHashMethodPm(w *coraza.Waf, opts string) error {
 	return nil
 }
 
-func directiveSecHashMethodRx(p *Parser, opts string) error {
+func directiveSecHashMethodRx(w *coraza.Waf, opts string) error {
 	return nil
 }
 
-func directiveSecHashParam(p *Parser, opts string) error {
+func directiveSecHashParam(w *coraza.Waf, opts string) error {
 	return nil
 }
 
-func directiveSecHashKey(p *Parser, opts string) error {
+func directiveSecHashKey(w *coraza.Waf, opts string) error {
 	return nil
 }
 
-func directiveSecHashEngine(p *Parser, opts string) error {
+func directiveSecHashEngine(w *coraza.Waf, opts string) error {
 	return nil
 }
 
-func directiveSecDefaultAction(p *Parser, opts string) error {
-	return p.addDefaultActions(opts)
-}
-
-func directiveSecContentInjection(p *Parser, opts string) error {
-	p.Waf.ContentInjection = parseBoolean(opts)
+func directiveSecDefaultAction(w *coraza.Waf, opts string) error {
+	da, ok := w.GetConfig("rule_default_actions").([]string)
+	if !ok {
+		da = []string{}
+	}
+	da = append(da, opts)
+	w.SetConfig("rule_default_actions", da)
 	return nil
 }
 
-func directiveSecConnEngine(p *Parser, opts string) error {
+func directiveSecContentInjection(w *coraza.Waf, opts string) error {
+	w.ContentInjection = parseBoolean(opts)
+	return nil
+}
+
+func directiveSecConnEngine(w *coraza.Waf, opts string) error {
 	/*
 		switch opts{
 		case "On":
-			p.waf.ConnEngine = engine.CONN_ENGINE_ON
+			w.ConnEngine = engine.CONN_ENGINE_ON
 			break
 		case "Off":
-			p.waf.ConnEngine = engine.CONN_ENGINE_OFF
+			w.ConnEngine = engine.CONN_ENGINE_OFF
 			break
 		case "DetectOnly":
-			p.waf.ConnEngine = engine.CONN_ENGINE_DETECTONLY
+			w.ConnEngine = engine.CONN_ENGINE_DETECTONLY
 			break
 		}
 		break
@@ -256,139 +284,139 @@ func directiveSecConnEngine(p *Parser, opts string) error {
 	return nil
 }
 
-func directiveSecCollectionTimeout(p *Parser, opts string) error {
-	// p.waf.CollectionTimeout, _ = strconv.Atoi(opts)
+func directiveSecCollectionTimeout(w *coraza.Waf, opts string) error {
+	// w.CollectionTimeout, _ = strconv.Atoi(opts)
 	return nil
 }
 
-func directiveSecAuditLog(p *Parser, opts string) error {
+func directiveSecAuditLog(w *coraza.Waf, opts string) error {
 	if len(opts) == 0 {
 		return errors.New("syntax error: SecAuditLog /some/absolute/path.log")
 	}
-	p.Waf.AuditLog = opts
-	if err := p.Waf.UpdateAuditLogger(); err != nil {
+	w.AuditLog = opts
+	if err := w.UpdateAuditLogger(); err != nil {
 		return err
 	}
 	return nil
 }
 
-func directiveSecAuditLogType(p *Parser, opts string) error {
+func directiveSecAuditLogType(w *coraza.Waf, opts string) error {
 	if len(opts) == 0 {
 		return errors.New("syntax error: SecAuditLogType [concurrent/https/serial/...]")
 	}
-	p.Waf.AuditLogType = strings.ToLower(opts)
-	if err := p.Waf.UpdateAuditLogger(); err != nil {
+	w.AuditLogType = strings.ToLower(opts)
+	if err := w.UpdateAuditLogger(); err != nil {
 		return err
 	}
 	return nil
 }
 
-func directiveSecAuditLogFormat(p *Parser, opts string) error {
+func directiveSecAuditLogFormat(w *coraza.Waf, opts string) error {
 	if len(opts) == 0 {
 		return errors.New("syntax error: SecAuditLogFormat [json/jsonlegacy/native/...]")
 	}
-	p.Waf.AuditLogFormat = strings.ToLower(opts)
-	if err := p.Waf.UpdateAuditLogger(); err != nil {
+	w.AuditLogFormat = strings.ToLower(opts)
+	if err := w.UpdateAuditLogger(); err != nil {
 		return err
 	}
 	return nil
 }
 
-func directiveSecAuditLogDir(p *Parser, opts string) error {
+func directiveSecAuditLogDir(w *coraza.Waf, opts string) error {
 	if len(opts) == 0 {
 		return errors.New("syntax error: SecAuditLogDir /some/absolute/path")
 	}
-	p.Waf.AuditLogDir = opts
-	if err := p.Waf.UpdateAuditLogger(); err != nil {
+	w.AuditLogDir = opts
+	if err := w.UpdateAuditLogger(); err != nil {
 		return err
 	}
 	return nil
 }
 
-func directiveSecAuditLogDirMode(p *Parser, opts string) error {
+func directiveSecAuditLogDirMode(w *coraza.Waf, opts string) error {
 	if len(opts) == 0 {
 		return errors.New("syntax error: SecAuditLogDirMode [0777/0700/...]")
 	}
-	// p.Waf.AuditLogDirMode, _ = strconv.ParseInt(opts, 8, 32)
-	if err := p.Waf.UpdateAuditLogger(); err != nil {
+	// w.AuditLogDirMode, _ = strconv.ParseInt(opts, 8, 32)
+	if err := w.UpdateAuditLogger(); err != nil {
 		return err
 	}
 	return nil
 }
 
-func directiveSecAuditLogFileMode(p *Parser, opts string) error {
+func directiveSecAuditLogFileMode(w *coraza.Waf, opts string) error {
 	if len(opts) == 0 {
 		return errors.New("syntax error: SecAuditLogFileMode [0777/0700/...]")
 	}
-	// p.Waf.AuditLogFileMode, _ = strconv.ParseInt(opts, 8, 32)
-	if err := p.Waf.UpdateAuditLogger(); err != nil {
+	// w.AuditLogFileMode, _ = strconv.ParseInt(opts, 8, 32)
+	if err := w.UpdateAuditLogger(); err != nil {
 		return err
 	}
 	return nil
 }
 
-func directiveSecAuditLogRelevantStatus(p *Parser, opts string) error {
+func directiveSecAuditLogRelevantStatus(w *coraza.Waf, opts string) error {
 	var err error
-	p.Waf.AuditLogRelevantStatus, err = regexp.Compile(opts)
+	w.AuditLogRelevantStatus, err = regexp.Compile(opts)
 	return err
 }
 
-func directiveSecAuditLogParts(p *Parser, opts string) error {
-	p.Waf.AuditLogParts = types.AuditLogParts(opts)
+func directiveSecAuditLogParts(w *coraza.Waf, opts string) error {
+	w.AuditLogParts = types.AuditLogParts(opts)
 	return nil
 }
 
-func directiveSecAuditEngine(p *Parser, opts string) error {
+func directiveSecAuditEngine(w *coraza.Waf, opts string) error {
 	au, err := types.ParseAuditEngineStatus(opts)
-	p.Waf.AuditEngine = au
+	w.AuditEngine = au
 	return err
 }
 
-func directiveSecDataDir(p *Parser, opts string) error {
+func directiveSecDataDir(w *coraza.Waf, opts string) error {
 	// TODO validations
-	p.Waf.DataDir = opts
+	w.DataDir = opts
 	return nil
 }
 
-func directiveSecUploadKeepFiles(p *Parser, opts string) error {
-	p.Waf.UploadKeepFiles = parseBoolean(opts)
+func directiveSecUploadKeepFiles(w *coraza.Waf, opts string) error {
+	w.UploadKeepFiles = parseBoolean(opts)
 	return nil
 }
 
-func directiveSecUploadFileMode(p *Parser, opts string) error {
+func directiveSecUploadFileMode(w *coraza.Waf, opts string) error {
 	fm, err := strconv.ParseInt(opts, 8, 32)
-	p.Waf.UploadFileMode = fs.FileMode(fm)
+	w.UploadFileMode = fs.FileMode(fm)
 	return err
 }
 
-func directiveSecUploadFileLimit(p *Parser, opts string) error {
+func directiveSecUploadFileLimit(w *coraza.Waf, opts string) error {
 	var err error
-	p.Waf.UploadFileLimit, err = strconv.Atoi(opts)
+	w.UploadFileLimit, err = strconv.Atoi(opts)
 	return err
 }
 
-func directiveSecUploadDir(p *Parser, opts string) error {
+func directiveSecUploadDir(w *coraza.Waf, opts string) error {
 	// TODO validations
-	p.Waf.UploadDir = opts
+	w.UploadDir = opts
 	return nil
 }
 
-func directiveSecRequestBodyNoFilesLimit(p *Parser, opts string) error {
+func directiveSecRequestBodyNoFilesLimit(w *coraza.Waf, opts string) error {
 	var err error
-	p.Waf.RequestBodyNoFilesLimit, err = strconv.ParseInt(opts, 10, 64)
+	w.RequestBodyNoFilesLimit, err = strconv.ParseInt(opts, 10, 64)
 	return err
 }
 
-func directiveSecDebugLog(p *Parser, opts string) error {
-	return p.Waf.SetDebugLogPath(opts)
+func directiveSecDebugLog(w *coraza.Waf, opts string) error {
+	return w.SetDebugLogPath(opts)
 }
 
-func directiveSecDebugLogLevel(p *Parser, opts string) error {
+func directiveSecDebugLogLevel(w *coraza.Waf, opts string) error {
 	lvl, err := strconv.Atoi(opts)
 	if err != nil {
 		return err
 	}
-	return p.Waf.SetLogLevel(lvl)
+	return w.SetLogLevel(lvl)
 }
 
 func parseBoolean(data string) bool {

--- a/seclang/directives.go
+++ b/seclang/directives.go
@@ -29,6 +29,10 @@ import (
 
 type directive = func(w *coraza.Waf, opts string) error
 
+func RegisterDirectivePlugin(name string, directive func(w *coraza.Waf, opts string) error) {
+	directivesMap[strings.ToLower(name)] = directive
+}
+
 func directiveSecComponentSignature(w *coraza.Waf, opts string) error {
 	w.ComponentNames = append(w.ComponentNames, opts)
 	return nil

--- a/seclang/directives.go
+++ b/seclang/directives.go
@@ -426,7 +426,7 @@ func directiveSecDebugLogLevel(w *coraza.Waf, opts string) error {
 func directiveSecRuleUpdateTargetById(w *coraza.Waf, opts string) error {
 	spl := strings.SplitN(opts, " ", 2)
 	if len(spl) != 2 {
-		return errors.New("syntax error: SecRuleUpdateTargetById id target")
+		return errors.New("syntax error: SecRuleUpdateTargetById id \"VARIABLES\"")
 	}
 	id, err := strconv.Atoi(spl[0])
 	if err != nil {

--- a/seclang/directives_test.go
+++ b/seclang/directives_test.go
@@ -121,11 +121,11 @@ func TestDebugDirectives(t *testing.T) {
 	tmpf, _ := ioutil.TempFile("/tmp", "*.log")
 	tmp := tmpf.Name()
 	p, _ := NewParser(waf)
-	err := directiveSecDebugLog(p, tmp)
+	err := directiveSecDebugLog(waf, tmp)
 	if err != nil {
 		t.Error(err)
 	}
-	if err := directiveSecDebugLogLevel(p, "5"); err != nil {
+	if err := directiveSecDebugLogLevel(waf, "5"); err != nil {
 		t.Error(err)
 	}
 	p.Waf.Logger.Info("abc123")
@@ -141,11 +141,10 @@ func TestSecAuditLogDirectivesDefaults(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	parser, _ := NewParser(waf)
-	if err := directiveSecAuditLog(parser, tmpf.Name()); err != nil {
+	if err := directiveSecAuditLog(waf, tmpf.Name()); err != nil {
 		t.Error(err)
 	}
-	if err := directiveSecAuditLogDir(parser, "/tmp"); err != nil {
+	if err := directiveSecAuditLogDir(waf, "/tmp"); err != nil {
 		t.Error(err)
 	}
 	if waf.AuditLogger() == nil {

--- a/seclang/directives_test.go
+++ b/seclang/directives_test.go
@@ -81,7 +81,7 @@ func Test_directiveSecAuditLog(t *testing.T) {
 	if err := p.FromString("SecRuleRemoveByTag test"); err != nil {
 		t.Error("failed to set parser from string")
 	}
-	if p.Waf.Rules.Count() != 0 {
+	if p.waf.Rules.Count() != 0 {
 		t.Error("Failed to remove rule with SecRuleRemoveByTag")
 	}
 	if err := p.FromString(`SecAction "id:1,msg:'test'"`); err != nil {
@@ -90,7 +90,7 @@ func Test_directiveSecAuditLog(t *testing.T) {
 	if err := p.FromString("SecRuleRemoveByMsg test"); err != nil {
 		t.Error("failed to set parser from string")
 	}
-	if p.Waf.Rules.Count() != 0 {
+	if p.waf.Rules.Count() != 0 {
 		t.Error("Failed to remove rule with SecRuleRemoveByMsg")
 	}
 	if err := p.FromString(`SecAction "id:1"`); err != nil {
@@ -99,19 +99,19 @@ func Test_directiveSecAuditLog(t *testing.T) {
 	if err := p.FromString("SecRuleRemoveById 1"); err != nil {
 		t.Error("failed to set parser from string")
 	}
-	if p.Waf.Rules.Count() != 0 {
+	if p.waf.Rules.Count() != 0 {
 		t.Error("Failed to remove rule with SecRuleRemoveById")
 	}
 	if err := p.FromString("SecResponseBodyMimeTypesClear"); err != nil {
 		t.Error("failed to set parser from string")
 	}
-	if len(p.Waf.ResponseBodyMimeTypes) != 0 {
+	if len(p.waf.ResponseBodyMimeTypes) != 0 {
 		t.Error("failed to set SecResponseBodyMimeTypesClear")
 	}
 	if err := p.FromString("SecResponseBodyMimeType text/html"); err != nil {
 		t.Error("failed to set parser from string")
 	}
-	if p.Waf.ResponseBodyMimeTypes[0] != "text/html" {
+	if p.waf.ResponseBodyMimeTypes[0] != "text/html" {
 		t.Error("failed to set SecResponseBodyMimeType")
 	}
 }
@@ -128,7 +128,7 @@ func TestDebugDirectives(t *testing.T) {
 	if err := directiveSecDebugLogLevel(waf, "5"); err != nil {
 		t.Error(err)
 	}
-	p.Waf.Logger.Info("abc123")
+	p.waf.Logger.Info("abc123")
 	data, _ := os.ReadFile(tmp)
 	if !strings.Contains(string(data), "abc123") {
 		t.Error("failed to write info log")

--- a/seclang/directives_test.go
+++ b/seclang/directives_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jptosso/coraza-waf/v2"
 	engine "github.com/jptosso/coraza-waf/v2"
 	"github.com/jptosso/coraza-waf/v2/loggers"
 	"github.com/jptosso/coraza-waf/v2/types"
@@ -209,6 +210,28 @@ func TestSecAuditLogDirectivesConcurrent(t *testing.T) {
 	if err := json.Unmarshal(data, &j); err != nil {
 		t.Error(err)
 	}
+}
+
+func TestSecRuleUpdateTargetBy(t *testing.T) {
+	waf := coraza.NewWaf()
+	rule, err := ParseRule(RuleOptions{
+		Data:         "REQUEST_URI \"^/test\" \"id:181,tag:test\"",
+		Waf:          waf,
+		WithOperator: true,
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	if err := waf.Rules.Add(rule); err != nil {
+		t.Error(err)
+	}
+	if waf.Rules.Count() != 1 {
+		t.Error("Failed to add rule")
+	}
+	if err := directiveSecRuleUpdateTargetById(waf, "181 \"REQUEST_HEADERS\""); err != nil {
+		t.Error(err)
+	}
+
 }
 
 // Find a file by name recursively containing some string

--- a/seclang/parser.go
+++ b/seclang/parser.go
@@ -104,7 +104,7 @@ func (p *Parser) FromString(data string) error {
 }
 
 func (p *Parser) evaluate(data string) error {
-	disabledDirectives, ok := p.waf.GetConfig("disabled_directives").([]string)
+	disabledDirectives, ok := p.waf.GetConfig("disabled_directives", []string{}).([]string)
 	if !ok {
 		disabledDirectives = []string{}
 	}

--- a/seclang/rule_parser.go
+++ b/seclang/rule_parser.go
@@ -249,7 +249,7 @@ func (p *ruleParser) ParseDefaultActions(actions string) error {
 
 // ParseActions
 func (p *ruleParser) ParseActions(actions string) error {
-	disabledActions, ok := p.options.Waf.GetConfig("disabled_rule_actions").([]string)
+	disabledActions, ok := p.options.Waf.GetConfig("disabled_rule_actions", []string{}).([]string)
 	if !ok {
 		disabledActions = []string{}
 	}
@@ -318,11 +318,11 @@ func ParseRule(options RuleOptions) (*coraza.Rule, error) {
 		defaultActions: map[types.RulePhase][]ruleAction{},
 	}
 
-	defaultActions, ok := options.Waf.GetConfig("rule_default_actions").([]string)
+	defaultActions, ok := options.Waf.GetConfig("rule_default_actions", []string{}).([]string)
 	if !ok {
 		defaultActions = []string{}
 	}
-	disabledRuleOperators, ok := options.Waf.GetConfig("disabled_rule_operators").([]string)
+	disabledRuleOperators, ok := options.Waf.GetConfig("disabled_rule_operators", []string{}).([]string)
 	if !ok {
 		disabledRuleOperators = []string{}
 	}

--- a/seclang/rule_parser.go
+++ b/seclang/rule_parser.go
@@ -37,13 +37,13 @@ type ruleAction struct {
 	F     coraza.RuleAction
 }
 
-type ruleParser struct {
+type RuleParser struct {
 	rule           *coraza.Rule
 	defaultActions map[types.RulePhase][]ruleAction
 	options        RuleOptions
 }
 
-func (p *ruleParser) ParseVariables(vars string) error {
+func (p *RuleParser) ParseVariables(vars string) error {
 
 	// 0 = variable name
 	// 1 = key
@@ -171,7 +171,7 @@ func (p *ruleParser) ParseVariables(vars string) error {
 	return nil
 }
 
-func (p *ruleParser) ParseOperator(operator string) error {
+func (p *RuleParser) ParseOperator(operator string) error {
 	if len(operator) == 0 || operator[0] != '@' && operator[0] != '!' {
 		// default operator RX
 		operator = "@rx " + operator
@@ -218,7 +218,7 @@ func (p *ruleParser) ParseOperator(operator string) error {
 	return nil
 }
 
-func (p *ruleParser) ParseDefaultActions(actions string) error {
+func (p *RuleParser) ParseDefaultActions(actions string) error {
 	act, err := parseActions(actions)
 	if err != nil {
 		return err
@@ -248,7 +248,7 @@ func (p *ruleParser) ParseDefaultActions(actions string) error {
 }
 
 // ParseActions
-func (p *ruleParser) ParseActions(actions string) error {
+func (p *RuleParser) ParseActions(actions string) error {
 	disabledActions, ok := p.options.Waf.GetConfig("disabled_rule_actions", []string{}).([]string)
 	if !ok {
 		disabledActions = []string{}
@@ -297,7 +297,7 @@ func (p *ruleParser) ParseActions(actions string) error {
 }
 
 // Rule returns the compiled rule
-func (p *ruleParser) Rule() *coraza.Rule {
+func (p *RuleParser) Rule() *coraza.Rule {
 	return p.rule
 }
 
@@ -312,7 +312,7 @@ type RuleOptions struct {
 
 func ParseRule(options RuleOptions) (*coraza.Rule, error) {
 	var err error
-	rp := &ruleParser{
+	rp := &RuleParser{
 		options:        options,
 		rule:           coraza.NewRule(),
 		defaultActions: map[types.RulePhase][]ruleAction{},

--- a/seclang/rule_parser_test.go
+++ b/seclang/rule_parser_test.go
@@ -21,23 +21,6 @@ import (
 	"github.com/jptosso/coraza-waf/v2"
 )
 
-func TestDefaultActions(t *testing.T) {
-	waf := coraza.NewWaf()
-	p, _ := NewParser(waf)
-	if err := p.addDefaultActions("log, pass, phase: 1"); err != nil {
-		t.Error("Error parsing default actions", err)
-	}
-	if err := p.addDefaultActions("log, drop, phase:2"); err != nil {
-		t.Error("Could not add default actions")
-	}
-	if len(p.defaultActions) != 2 {
-		t.Error("Default actions were not created")
-	}
-	if err := p.FromString(`SecAction "phase:2, id:1"`); err != nil {
-		t.Error("Could not create from string")
-	}
-}
-
 func TestMergeActions(t *testing.T) {
 
 }

--- a/seclang/rules_test.go
+++ b/seclang/rules_test.go
@@ -270,3 +270,17 @@ func TestStatusFromInterruptions(t *testing.T) {
 		t.Errorf("failed to set status, got %d", it.Status)
 	}
 }
+
+func TestChainWithUnconditionalMatch(t *testing.T) {
+	waf := coraza.NewWaf()
+	p, _ := NewParser(waf)
+	if err := p.FromString(`
+	SecAction "id:7, pass, phase:1, log, chain, skip:2"
+    SecRule REMOTE_ADDR "@unconditionalMatch" ""
+	`); err != nil {
+		t.Error(err)
+	}
+	if waf.Rules.Count() != 1 {
+		t.Errorf("invalid rule count, got %d", waf.Rules.Count())
+	}
+}

--- a/testdata/engine/default_actions.yaml
+++ b/testdata/engine/default_actions.yaml
@@ -1,0 +1,45 @@
+---
+  meta:
+    author: jptosso
+    description: Test if the default_actions work
+    enabled: true
+    name: default_actions.yaml
+  tests:
+  -
+    test_title: default_actions
+    stages:
+    -
+      stage:
+        input:
+          uri: /%FFindex.html?test=test1
+        output:
+          triggered_rules:
+            - 6
+            - 7
+            - 8
+            - 9
+            - 10
+          non_triggered_rules:
+            - 1
+            - 2
+            - 3
+            - 4
+            - 5
+  rules: |
+    SecAction "id:1, phase:1, pass"
+    SecAction "id:2, phase:2, pass"
+    SecAction "id:3, phase:3, pass"
+    SecAction "id:4, phase:4, pass"
+    SecAction "id:5, phase:5, pass"
+
+    SecDefaultAction "phase:1,pass,log"
+    SecDefaultAction "phase:2,pass,log"
+    SecDefaultAction "phase:3,pass,log"
+    SecDefaultAction "phase:4,pass,log"
+    SecDefaultAction "phase:5,pass,log"
+
+    SecAction "id:6, phase:1, pass"
+    SecAction "id:7, phase:2, pass"
+    SecAction "id:8, phase:3, pass"
+    SecAction "id:9, phase:4, pass"
+    SecAction "id:10, phase:5, pass"    

--- a/testing/profile.go
+++ b/testing/profile.go
@@ -77,7 +77,7 @@ func (p *Profile) TestList(waf *coraza.Waf) ([]*Test, error) {
 			if w == nil || p.Rules != "" {
 				w = coraza.NewWaf()
 				parser, _ := seclang.NewParser(w)
-				parser.Configdir = "../testdata/"
+				parser.SetCurrentDir("../testdata/")
 				if err := parser.FromString(p.Rules); err != nil {
 					return nil, err
 				}

--- a/transformations/transformations.go
+++ b/transformations/transformations.go
@@ -16,6 +16,7 @@ package transformations
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/jptosso/coraza-waf/v2"
 )
@@ -25,13 +26,13 @@ var transformations = map[string]coraza.RuleTransformation{}
 // RegisterPlugin registers a transformation by name
 // If the transformation is already registered, it will be overwritten
 func RegisterPlugin(name string, trans coraza.RuleTransformation) {
-	transformations[name] = trans
+	transformations[strings.ToLower(name)] = trans
 }
 
 // GetTransformation returns a transformation by name
 // If the transformation is not found, it returns an error
 func GetTransformation(name string) (coraza.RuleTransformation, error) {
-	if t, ok := transformations[name]; ok {
+	if t, ok := transformations[strings.ToLower(name)]; ok {
 		return t, nil
 	}
 	return nil, fmt.Errorf("invalid transformation name %q", name)

--- a/transformations/transformations_test.go
+++ b/transformations/transformations_test.go
@@ -83,3 +83,12 @@ func TestTransformations(t *testing.T) {
 		}
 	}
 }
+
+func TestTransformationsAreCaseInsensitive(t *testing.T) {
+	if _, err := GetTransformation("cmdLine"); err != nil {
+		t.Error(err)
+	}
+	if _, err := GetTransformation("cmdline"); err != nil {
+		t.Error(err)
+	}
+}

--- a/waf.go
+++ b/waf.go
@@ -157,6 +157,8 @@ type Waf struct {
 	loggerAtomicLevel *zap.AtomicLevel
 
 	errorLogCb ErrorLogCallback
+
+	config map[string]interface{}
 }
 
 // NewTransaction Creates a new initialized transaction for this WAF instance
@@ -349,6 +351,7 @@ func NewWaf() *Waf {
 		CollectionTimeout:        3600,
 		loggerAtomicLevel:        &atom,
 		AuditLogRelevantStatus:   regexp.MustCompile(`.*`),
+		config:                   map[string]interface{}{},
 	}
 	if err := waf.SetDebugLogPath("/dev/null"); err != nil {
 		fmt.Println(err)
@@ -397,4 +400,16 @@ func (w *Waf) SetGeoReader(reader geo.Reader) {
 // A geo processor requires a Geo plugin to be installed
 func (w *Waf) Geo() geo.Reader {
 	return w.geo
+}
+
+// SetConfig is used to share configuration from directives
+// to Transactions. This function is not concurrent-safe.
+func (w *Waf) SetConfig(key string, value interface{}) {
+	w.config[key] = value
+}
+
+// GetConfig returns the configuration value for the given key.
+// This function is concurrent-safe.
+func (w *Waf) GetConfig(key string) interface{} {
+	return w.config[key]
 }

--- a/waf.go
+++ b/waf.go
@@ -409,7 +409,11 @@ func (w *Waf) SetConfig(key string, value interface{}) {
 }
 
 // GetConfig returns the configuration value for the given key.
+// If the key is not found, defaultValue is returned
 // This function is concurrent-safe.
-func (w *Waf) GetConfig(key string) interface{} {
-	return w.config[key]
+func (w *Waf) GetConfig(key string, defaultValue interface{}) interface{} {
+	if value, ok := w.config[key]; ok {
+		return value
+	}
+	return defaultValue
 }


### PR DESCRIPTION
Parser now supports directives plugins

- SecRuleUpdateTargetById was implemented
- waf.GetConfig and SetConfig were added to share interfaces between operators, actions and directives