### PR TITLE
feat: integrate libinjection-go

### DIFF
--- a/.github/workflows/go-ftw.yml
+++ b/.github/workflows/go-ftw.yml
@@ -24,18 +24,6 @@ jobs:
       with:
         lfs: true
         fetch-depth: 0 #for better blame info
-    - name: Prepare libinjection and PCRE
-      run: |
-        git clone https://github.com/libinjection/libinjection
-        gcc -std=c99 -Wall -Werror -fpic -c libinjection/src/libinjection_sqli.c -o libinjection/libinjection_sqli.o 
-        gcc -std=c99 -Wall -Werror -fpic -c libinjection/src/libinjection_xss.c -o libinjection/libinjection_xss.o
-        gcc -std=c99 -Wall -Werror -fpic -c libinjection/src/libinjection_html5.c -o libinjection/libinjection_html5.o
-        gcc -dynamiclib -shared -o libinjection/libinjection.so libinjection/libinjection_sqli.o libinjection/libinjection_xss.o libinjection/libinjection_html5.o
-        sudo cp libinjection/*.so /usr/local/lib
-        sudo cp libinjection/*.o /usr/local/lib
-        sudo cp libinjection/src/*.h /usr/local/include/
-        sudo chmod 444 /usr/local/include/libinjection*
-        sudo ldconfig
     - name: Create Caddyfile
       run: |
         wget https://gist.githubusercontent.com/jptosso/d3aca6d062c816b732aab358f28bbc3f/raw/18b1dfcabcb63c5e2dbad68ff25a5af4b1d3fd7d/Caddyfile
@@ -52,11 +40,10 @@ jobs:
         sed -i 's/\/some\/path\/to\/log.log/\/tmp\/output.log/g' .ftw.yaml
         sed -i 's/\/\/ _ "github.com/_ "github.com/g' main.go
         mv main.go caddy/main.go
-        go get github.com/jptosso/coraza-caddy@51db837
+        go get github.com/jptosso/coraza-caddy@9c2db28
         go mod tidy
         go get ./...
         go get -u github.com/jptosso/coraza-pcre@1bea0f0
-        go get -u github.com/jptosso/coraza-libinjection@f462893
         go install caddy/main.go
         sudo setcap CAP_NET_BIND_SERVICE=+eip $(which caddy)
     - name: Start Caddy server

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jptosso/coraza-waf/v2
 go 1.16
 
 require (
+	github.com/bxlxx/libinjection-go v0.0.0-20220128023607-8945e6330cec
 	github.com/cloudflare/ahocorasick v0.0.0-20210425175752-730270c3e184
 	go.uber.org/zap v1.20.0
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
+github.com/bxlxx/libinjection-go v0.0.0-20220128023607-8945e6330cec h1:EyWWsPy3d915+csqXykv0KGW7RWtYaQWtl0IxMvtPLU=
+github.com/bxlxx/libinjection-go v0.0.0-20220128023607-8945e6330cec/go.mod h1:MkUMssQuR4IHCbJogYZB0Y1IJzfgWu06HeaEgdtn17c=
 github.com/cloudflare/ahocorasick v0.0.0-20210425175752-730270c3e184 h1:8yL+85JpbwrIc6m+7N1iYrjn/22z68jwrTIBOJHNe4k=
 github.com/cloudflare/ahocorasick v0.0.0-20210425175752-730270c3e184/go.mod h1:tGWUZLZp9ajsxUOnHmFFLnqnlKXsCn6GReG4jAD59H0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/operators/detect_sqli.go
+++ b/operators/detect_sqli.go
@@ -1,0 +1,38 @@
+// Copyright 2022 Juan Pablo Tosso
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operators
+
+import (
+	"github.com/bxlxx/libinjection-go"
+	"github.com/jptosso/coraza-waf/v2"
+)
+
+type detectSQLi struct {
+}
+
+func (o *detectSQLi) Init(data string) error {
+	return nil
+}
+
+func (o *detectSQLi) Evaluate(tx *coraza.Transaction, value string) bool {
+	res, fingerprint := libinjection.IsSQLi(value)
+	if !res {
+		return false
+	}
+	if tx.Capture {
+		tx.CaptureField(0, string(fingerprint))
+	}
+	return true
+}

--- a/operators/detect_xss.go
+++ b/operators/detect_xss.go
@@ -1,0 +1,31 @@
+// Copyright 2022 Juan Pablo Tosso
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operators
+
+import (
+	"github.com/bxlxx/libinjection-go"
+	"github.com/jptosso/coraza-waf/v2"
+)
+
+type detectXSS struct {
+}
+
+func (o *detectXSS) Init(data string) error {
+	return nil
+}
+
+func (o *detectXSS) Evaluate(tx *coraza.Transaction, value string) bool {
+	return libinjection.IsXSS(value)
+}

--- a/operators/operators.go
+++ b/operators/operators.go
@@ -49,6 +49,8 @@ func init() {
 	RegisterPlugin("noMatch", func() coraza.RuleOperator { return &noMatch{} })
 	RegisterPlugin("validateNid", func() coraza.RuleOperator { return &validateNid{} })
 	RegisterPlugin("geoLookup", func() coraza.RuleOperator { return &geoLookup{} })
+	RegisterPlugin("detectSQLi", func() coraza.RuleOperator { return &detectSQLi{} })
+	RegisterPlugin("detectXSS", func() coraza.RuleOperator { return &detectXSS{} })
 }
 
 // GetOperator returns an operator by name

--- a/seclang/directives.go
+++ b/seclang/directives.go
@@ -89,6 +89,7 @@ func directiveSecRule(w *coraza.Waf, opts string) error {
 	line := w.Config.Get("parser_last_line", 0).(int)
 	configFile := w.Config.Get("parser_config_file", "").(string)
 	configDir := w.Config.Get("parser_config_dir", "").(string)
+	ignoreErrors := w.Config.Get("ignore_rule_compilation_errors", false).(bool)
 	rule, err := ParseRule(RuleOptions{
 		Waf:          w,
 		Data:         opts,
@@ -97,13 +98,26 @@ func directiveSecRule(w *coraza.Waf, opts string) error {
 		ConfigFile:   configFile,
 		ConfigDir:    configDir,
 	})
-	if err != nil {
-		if perr := fmt.Errorf("Failed to compile rule (%s): %s", err, opts); perr != nil {
-			return perr // can't write to log, return this instead
-		}
-		return err
+	if err != nil && !ignoreErrors {
+		return fmt.Errorf("Failed to compile rule (%s): %s", err, opts)
+	} else if err != nil && ignoreErrors {
+		w.Logger.Debug("Ignoring rule compilation error",
+			zap.String("rule", opts),
+			zap.Error(err),
+		)
+		return nil
 	}
-	return w.Rules.Add(rule)
+	err = w.Rules.Add(rule)
+	if err != nil && !ignoreErrors {
+		return err
+	} else if err != nil && ignoreErrors {
+		w.Logger.Debug("Ignoring rule compilation error",
+			zap.String("rule", opts),
+			zap.Error(err),
+		)
+		return nil
+	}
+	return nil
 }
 
 func directiveSecResponseBodyAccess(w *coraza.Waf, opts string) error {
@@ -267,7 +281,11 @@ func directiveSecDefaultAction(w *coraza.Waf, opts string) error {
 }
 
 func directiveSecContentInjection(w *coraza.Waf, opts string) error {
-	w.ContentInjection = parseBoolean(opts)
+	b, err := parseBoolean(opts)
+	if err != nil {
+		return newDirectiveError(err, "SecContentInjection")
+	}
+	w.ContentInjection = b
 	return nil
 }
 
@@ -400,7 +418,11 @@ func directiveSecDataDir(w *coraza.Waf, opts string) error {
 }
 
 func directiveSecUploadKeepFiles(w *coraza.Waf, opts string) error {
-	w.UploadKeepFiles = parseBoolean(opts)
+	b, err := parseBoolean(opts)
+	if err != nil {
+		return newDirectiveError(err, "SecUploadKeepFiles")
+	}
+	w.UploadKeepFiles = b
 	return nil
 }
 
@@ -458,9 +480,33 @@ func directiveSecRuleUpdateTargetById(w *coraza.Waf, opts string) error {
 	return rp.ParseVariables(strings.Trim(spl[1], "\""))
 }
 
-func parseBoolean(data string) bool {
+func directiveSecIgnoreRuleCompilationErrors(w *coraza.Waf, opts string) error {
+	b, err := parseBoolean(opts)
+	if err != nil {
+		return newDirectiveError(err, "SecIgnoreRuleCompilationErrors")
+	}
+	if b {
+		w.Logger.Warn(`Coraza is running in Compatibility Mode (SecIgnoreRuleCompilationErrors On)
+		, which may cause unexpected behavior on faulty rules.`)
+	}
+	w.Config.Set("ignore_rule_compilation_errors", b)
+	return nil
+}
+
+func newDirectiveError(err error, directive string) error {
+	return fmt.Errorf("syntax error for directive %s: %s", directive, err)
+}
+
+func parseBoolean(data string) (bool, error) {
 	data = strings.ToLower(data)
-	return data == "on"
+	switch data {
+	case "on":
+		return true, nil
+	case "off":
+		return false, nil
+	default:
+		return false, errors.New("syntax error: [on/off]")
+	}
 }
 
 var (
@@ -489,62 +535,63 @@ var (
 )
 
 var directivesMap = map[string]directive{
-	"secwebappid":                   directiveSecWebAppID,
-	"secuploadkeepfiles":            directiveSecUploadKeepFiles,
-	"secuploadfilemode":             directiveSecUploadFileMode,
-	"secuploadfilelimit":            directiveSecUploadFileLimit,
-	"secuploaddir":                  directiveSecUploadDir,
-	"sectmpdir":                     directiveSecTmpDir,
-	"secserversignature":            directiveSecServerSignature,
-	"secsensorid":                   directiveSecSensorID,
-	"secruleremovebytag":            directiveSecRuleRemoveByTag,
-	"secruleremovebymsg":            directiveSecRuleRemoveByMsg,
-	"secruleremovebyid":             directiveSecRuleRemoveByID,
-	"secruleengine":                 directiveSecRuleEngine,
-	"secrule":                       directiveSecRule,
-	"secresponsebodymimetypesclear": directiveSecResponseBodyMimeTypesClear,
-	"secresponsebodymimetype":       directiveSecResponseBodyMimeType,
-	"secresponsebodylimitaction":    directiveSecResponseBodyLimitAction,
-	"secresponsebodylimit":          directiveSecResponseBodyLimit,
-	"secresponsebodyaccess":         directiveSecResponseBodyAccess,
-	"secrequestbodynofileslimit":    directiveSecRequestBodyNoFilesLimit,
-	"secrequestbodylimitaction":     directiveSecRequestBodyLimitAction,
-	"secrequestbodylimit":           directiveSecRequestBodyLimit,
-	"secrequestbodyinmemorylimit":   directiveSecRequestBodyInMemoryLimit,
-	"secrequestbodyaccess":          directiveSecRequestBodyAccess,
-	"secremoterulesfailaction":      directiveSecRemoteRulesFailAction,
-	"secremoterules":                directiveSecRemoteRules,
-	"secpcrematchlimitrecursion":    directiveSecPcreMatchLimitRecursion,
-	"secpcrematchlimit":             directiveSecPcreMatchLimit,
-	"secmarker":                     directiveSecMarker,
-	"sechttpblkey":                  directiveSecHTTPBlKey,
-	"sechashparam":                  directiveSecHashParam,
-	"sechashmethodrx":               directiveSecHashMethodRx,
-	"sechashmethodpm":               directiveSecHashMethodPm,
-	"sechashkey":                    directiveSecHashKey,
-	"sechashengine":                 directiveSecHashEngine,
-	"secgsblookupdb":                directiveSecGsbLookupDb,
-	"secdefaultaction":              directiveSecDefaultAction,
-	"secdatadir":                    directiveSecDataDir,
-	"seccontentinjection":           directiveSecContentInjection,
-	"secconnwritestatelimit":        directiveSecConnWriteStateLimit,
-	"secconnreadstatelimit":         directiveSecConnReadStateLimit,
-	"secconnengine":                 directiveSecConnEngine,
-	"seccomponentsignature":         directiveSecComponentSignature,
-	"seccollectiontimeout":          directiveSecCollectionTimeout,
-	"secauditlogrelevantstatus":     directiveSecAuditLogRelevantStatus,
-	"secauditlogparts":              directiveSecAuditLogParts,
-	"secauditlogdir":                directiveSecAuditLogDir,
-	"secauditlogstoragedir":         directiveSecAuditLogDir,
-	"secauditlog":                   directiveSecAuditLog,
-	"secauditengine":                directiveSecAuditEngine,
-	"secaction":                     directiveSecAction,
-	"secdebuglog":                   directiveSecDebugLog,
-	"secdebugloglevel":              directiveSecDebugLogLevel,
-	"secauditlogformat":             directiveSecAuditLogFormat,
-	"secauditlogtype":               directiveSecAuditLogType,
-	"secauditlogfilemode":           directiveSecAuditLogFileMode,
-	"secauditlogdirmode":            directiveSecAuditLogDirMode,
+	"secwebappid":                    directiveSecWebAppID,
+	"secuploadkeepfiles":             directiveSecUploadKeepFiles,
+	"secuploadfilemode":              directiveSecUploadFileMode,
+	"secuploadfilelimit":             directiveSecUploadFileLimit,
+	"secuploaddir":                   directiveSecUploadDir,
+	"sectmpdir":                      directiveSecTmpDir,
+	"secserversignature":             directiveSecServerSignature,
+	"secsensorid":                    directiveSecSensorID,
+	"secruleremovebytag":             directiveSecRuleRemoveByTag,
+	"secruleremovebymsg":             directiveSecRuleRemoveByMsg,
+	"secruleremovebyid":              directiveSecRuleRemoveByID,
+	"secruleengine":                  directiveSecRuleEngine,
+	"secrule":                        directiveSecRule,
+	"secresponsebodymimetypesclear":  directiveSecResponseBodyMimeTypesClear,
+	"secresponsebodymimetype":        directiveSecResponseBodyMimeType,
+	"secresponsebodylimitaction":     directiveSecResponseBodyLimitAction,
+	"secresponsebodylimit":           directiveSecResponseBodyLimit,
+	"secresponsebodyaccess":          directiveSecResponseBodyAccess,
+	"secrequestbodynofileslimit":     directiveSecRequestBodyNoFilesLimit,
+	"secrequestbodylimitaction":      directiveSecRequestBodyLimitAction,
+	"secrequestbodylimit":            directiveSecRequestBodyLimit,
+	"secrequestbodyinmemorylimit":    directiveSecRequestBodyInMemoryLimit,
+	"secrequestbodyaccess":           directiveSecRequestBodyAccess,
+	"secremoterulesfailaction":       directiveSecRemoteRulesFailAction,
+	"secremoterules":                 directiveSecRemoteRules,
+	"secpcrematchlimitrecursion":     directiveSecPcreMatchLimitRecursion,
+	"secpcrematchlimit":              directiveSecPcreMatchLimit,
+	"secmarker":                      directiveSecMarker,
+	"sechttpblkey":                   directiveSecHTTPBlKey,
+	"sechashparam":                   directiveSecHashParam,
+	"sechashmethodrx":                directiveSecHashMethodRx,
+	"sechashmethodpm":                directiveSecHashMethodPm,
+	"sechashkey":                     directiveSecHashKey,
+	"sechashengine":                  directiveSecHashEngine,
+	"secgsblookupdb":                 directiveSecGsbLookupDb,
+	"secdefaultaction":               directiveSecDefaultAction,
+	"secdatadir":                     directiveSecDataDir,
+	"seccontentinjection":            directiveSecContentInjection,
+	"secconnwritestatelimit":         directiveSecConnWriteStateLimit,
+	"secconnreadstatelimit":          directiveSecConnReadStateLimit,
+	"secconnengine":                  directiveSecConnEngine,
+	"seccomponentsignature":          directiveSecComponentSignature,
+	"seccollectiontimeout":           directiveSecCollectionTimeout,
+	"secauditlogrelevantstatus":      directiveSecAuditLogRelevantStatus,
+	"secauditlogparts":               directiveSecAuditLogParts,
+	"secauditlogdir":                 directiveSecAuditLogDir,
+	"secauditlogstoragedir":          directiveSecAuditLogDir,
+	"secauditlog":                    directiveSecAuditLog,
+	"secauditengine":                 directiveSecAuditEngine,
+	"secaction":                      directiveSecAction,
+	"secdebuglog":                    directiveSecDebugLog,
+	"secdebugloglevel":               directiveSecDebugLogLevel,
+	"secauditlogformat":              directiveSecAuditLogFormat,
+	"secauditlogtype":                directiveSecAuditLogType,
+	"secauditlogfilemode":            directiveSecAuditLogFileMode,
+	"secauditlogdirmode":             directiveSecAuditLogDirMode,
+	"secignorerulecompilationerrors": directiveSecIgnoreRuleCompilationErrors,
 
 	// Unsupported Directives
 	"secargumentseparator":     directiveUnsupported,

--- a/seclang/directives_test.go
+++ b/seclang/directives_test.go
@@ -23,14 +23,13 @@ import (
 	"testing"
 
 	"github.com/jptosso/coraza-waf/v2"
-	engine "github.com/jptosso/coraza-waf/v2"
 	"github.com/jptosso/coraza-waf/v2/loggers"
 	"github.com/jptosso/coraza-waf/v2/types"
 	utils "github.com/jptosso/coraza-waf/v2/utils/strings"
 )
 
 func Test_directiveSecAuditLog(t *testing.T) {
-	w := engine.NewWaf()
+	w := coraza.NewWaf()
 	p, _ := NewParser(w)
 	if err := p.FromString("SecWebAppId test123"); err != nil {
 		t.Error("failed to set parser from string")
@@ -119,7 +118,7 @@ func Test_directiveSecAuditLog(t *testing.T) {
 }
 
 func TestDebugDirectives(t *testing.T) {
-	waf := engine.NewWaf()
+	waf := coraza.NewWaf()
 	tmpf, _ := ioutil.TempFile("/tmp", "*.log")
 	tmp := tmpf.Name()
 	p, _ := NewParser(waf)
@@ -138,7 +137,7 @@ func TestDebugDirectives(t *testing.T) {
 }
 
 func TestSecAuditLogDirectivesConcurrent(t *testing.T) {
-	waf := engine.NewWaf()
+	waf := coraza.NewWaf()
 	auditpath := "/tmp/"
 	parser, _ := NewParser(waf)
 	if err := parser.FromString(`
@@ -231,4 +230,30 @@ func findFileContaining(path string, search string) (string, error) {
 		}
 	}
 	return "", nil
+}
+
+func TestInvalidBooleanForDirectives(t *testing.T) {
+	waf := coraza.NewWaf()
+	p, _ := NewParser(waf)
+	if err := p.FromString("SecIgnoreRuleCompilationErrors sure"); err == nil {
+		t.Error("failed to error on invalid boolean")
+	}
+}
+
+func TestInvalidRulesWithIgnoredErrors(t *testing.T) {
+	directives := `
+	SecRule REQUEST_URI "@no_op ^/test" "id:181,tag:test"
+	SecRule REQUEST_URI "@no_op ^/test" "id:200,tag:test,invalid:5"
+	SecRule REQUEST_URI "@rx ^/test" "id:181,tag:repeated-id"
+	`
+	waf := coraza.NewWaf()
+	p, _ := NewParser(waf)
+	if err := p.FromString("secignorerulecompilationerrors On\n" + directives); err != nil {
+		t.Error(err)
+	}
+	waf = coraza.NewWaf()
+	p, _ = NewParser(waf)
+	if err := p.FromString(directives); err == nil {
+		t.Error("failed to error on invalid rule")
+	}
 }


### PR DESCRIPTION
This is an awesome PR, now we do not require libinjection anymore, thank you @bxlxx for your amazing contribution.

Coraza now officially supports detectSQLi and detectXSS without plugins or CGO.